### PR TITLE
Add Flask web server for ChatGPT speech transcription

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
+# Speech-to-Text Demo
 
+This project provides a simple Flask-based web server that sends audio files to the ChatGPT API for transcription. It supports the `gpt-4o-mini-transcribe` and `gpt-4o-transcribe` models, and allows customization of the API `base_url` and `api_key` at runtime.
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running
+
+```bash
+python app.py
+```
+
+Visit `http://localhost:5000` in your browser. Provide your API key, optionally override the base URL, choose a model, and upload an audio file to receive a transcription.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,55 @@
+from flask import Flask, request, render_template_string, jsonify
+from openai import OpenAI
+import io
+
+app = Flask(__name__)
+
+HTML_FORM = """
+<!doctype html>
+<title>Speech to Text Demo</title>
+<h1>Upload audio for transcription</h1>
+<form method="post" enctype="multipart/form-data" action="/transcribe">
+  Base URL: <input type="text" name="base_url" value="https://api.openai.com/v1"><br>
+  API Key: <input type="text" name="api_key"><br>
+  Model: <select name="model">
+    <option value="gpt-4o-mini-transcribe">gpt-4o-mini-transcribe</option>
+    <option value="gpt-4o-transcribe">gpt-4o-transcribe</option>
+  </select><br>
+  Audio File: <input type="file" name="audio"><br>
+  <input type="submit" value="Transcribe">
+</form>
+"""
+
+@app.route('/', methods=['GET'])
+def index():
+    return render_template_string(HTML_FORM)
+
+@app.route('/transcribe', methods=['POST'])
+def transcribe():
+    api_key = request.form.get('api_key')
+    base_url = request.form.get('base_url') or "https://api.openai.com/v1"
+    model = request.form.get('model', 'gpt-4o-mini-transcribe')
+    audio = request.files.get('audio')
+
+    if not api_key or audio is None:
+        return "Missing API key or audio file", 400
+
+    client = OpenAI(api_key=api_key, base_url=base_url)
+
+    audio_bytes = audio.read()
+    buf = io.BytesIO(audio_bytes)
+    buf.name = audio.filename or 'audio.wav'
+
+    try:
+        result = client.audio.transcriptions.create(
+            model=model,
+            file=buf
+        )
+        text = result.text
+    except Exception as e:
+        return f"Error: {e}", 500
+
+    return jsonify({"text": text})
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000, debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flask
+openai


### PR DESCRIPTION
## Summary
- add Flask server to upload audio and transcribe via ChatGPT API
- allow custom base URL, API key, and model (gpt-4o-mini-transcribe or gpt-4o-transcribe)
- provide setup instructions

## Testing
- `pip install --quiet -r requirements.txt`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_688e35b80df883328dcac37ca33da084