### PR TITLE
Add Flask web server for ChatGPT speech transcription

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
+# Speech-to-Text Demo
 
+This project provides a simple Flask-based web server that sends audio input to the ChatGPT API for transcription. It supports the `gpt-4o-mini-transcribe` and `gpt-4o-transcribe` models, and allows customization of the API `base_url` and `api_key` at runtime. You can upload an audio file or record from your microphone directly in the browser.
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running
+
+```bash
+python app.py
+```
+
+Visit `http://localhost:5001` in your browser. Provide your API key, optionally override the base URL, choose a model, and either upload an audio file or record using your microphone to receive a transcription.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,39 @@
+from flask import Flask, request, render_template, jsonify
+from openai import OpenAI
+import io
+
+app = Flask(__name__)
+
+@app.route('/', methods=['GET'])
+def index():
+    return render_template('index.html')
+
+@app.route('/transcribe', methods=['POST'])
+def transcribe():
+    api_key = request.form.get('api_key')
+    base_url = request.form.get('base_url') or "https://api.openai.com/v1"
+    model = request.form.get('model', 'gpt-4o-mini-transcribe')
+    audio = request.files.get('audio')
+
+    if not api_key or audio is None:
+        return "Missing API key or audio file", 400
+
+    client = OpenAI(api_key=api_key, base_url=base_url)
+
+    audio_bytes = audio.read()
+    buf = io.BytesIO(audio_bytes)
+    buf.name = audio.filename or 'audio.wav'
+
+    try:
+        result = client.audio.transcriptions.create(
+            model=model,
+            file=buf
+        )
+        text = result.text
+    except Exception as e:
+        return f"Error: {e}", 500
+
+    return jsonify({"text": text})
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5001, debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flask
+openai

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,89 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Speech to Text Demo</title>
+  <style>
+    body { font-family: Arial, sans-serif; background: #f5f5f5; }
+    .container { max-width: 600px; margin: 40px auto; background: #fff; padding: 20px; border-radius: 8px; box-shadow: 0 0 10px rgba(0,0,0,0.1); }
+    label { display: block; margin-top: 10px; }
+    input[type="text"], select { width: 100%; padding: 8px; margin-top: 5px; box-sizing: border-box; }
+    input[type="file"] { margin-top: 5px; }
+    button { margin-top: 10px; padding: 10px 15px; }
+    #result { white-space: pre-wrap; margin-top: 20px; background: #eee; padding: 10px; border-radius: 4px; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Speech to Text Demo</h1>
+    <form id="transcribe-form">
+      <label>Base URL
+        <input type="text" name="base_url" value="https://api.openai.com/v1">
+      </label>
+      <label>API Key
+        <input type="text" name="api_key">
+      </label>
+      <label>Model
+        <select name="model">
+          <option value="gpt-4o-mini-transcribe">gpt-4o-mini-transcribe</option>
+          <option value="gpt-4o-transcribe">gpt-4o-transcribe</option>
+        </select>
+      </label>
+      <label>Audio File
+        <input type="file" id="audio" name="audio">
+      </label>
+      <div>
+        <button type="button" onclick="startRecording()">Start Recording</button>
+        <button type="button" onclick="stopRecording()">Stop Recording</button>
+        <button type="button" onclick="transcribe()">Transcribe</button>
+      </div>
+    </form>
+    <p id="status"></p>
+    <pre id="result"></pre>
+  </div>
+
+  <script>
+    let mediaRecorder;
+    let recordedChunks = [];
+
+    function startRecording() {
+      recordedChunks = [];
+      navigator.mediaDevices.getUserMedia({ audio: true }).then(stream => {
+        mediaRecorder = new MediaRecorder(stream);
+        mediaRecorder.start();
+        document.getElementById('status').innerText = 'Recording...';
+        mediaRecorder.addEventListener('dataavailable', e => recordedChunks.push(e.data));
+      }).catch(err => {
+        document.getElementById('status').innerText = 'Microphone access denied.';
+      });
+    }
+
+    function stopRecording() {
+      if (mediaRecorder && mediaRecorder.state !== 'inactive') {
+        mediaRecorder.stop();
+        document.getElementById('status').innerText = 'Recording stopped.';
+      }
+    }
+
+    function transcribe() {
+      const form = document.getElementById('transcribe-form');
+      const formData = new FormData(form);
+      if (recordedChunks.length > 0) {
+        const blob = new Blob(recordedChunks, { type: 'audio/webm' });
+        formData.set('audio', blob, 'recording.webm');
+      } else if (!document.getElementById('audio').files[0]) {
+        alert('Please record or upload an audio file.');
+        return;
+      }
+      fetch('/transcribe', { method: 'POST', body: formData })
+        .then(res => res.json())
+        .then(data => {
+          document.getElementById('result').innerText = data.text || JSON.stringify(data);
+        })
+        .catch(err => {
+          document.getElementById('result').innerText = 'Error: ' + err;
+        });
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add styled HTML interface with audio upload and microphone recording
- serve new template and update server port to 5001
- document microphone feature and new port

## Testing
- `pip install --quiet -r requirements.txt`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_688e35b80df883328dcac37ca33da084