### PR TITLE
Add microphone-enabled UI and change default port

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ pip install -r requirements.txt
 python app.py
 ```
 
-Visit `http://localhost:5000` in your browser. Provide your API key, optionally override the base URL, choose a model, and upload an audio file to receive a transcription.
+Visit `http://localhost:5001` in your browser. The interface now includes a microphone button so you can record audio directly in the page, or upload an existing file. Provide your API key, optionally override the base URL, choose a model, and submit the audio to receive a transcription.

--- a/app.py
+++ b/app.py
@@ -1,28 +1,13 @@
-from flask import Flask, request, render_template_string, jsonify
+from flask import Flask, request, render_template, jsonify
 from openai import OpenAI
 import io
 
 app = Flask(__name__)
 
-HTML_FORM = """
-<!doctype html>
-<title>Speech to Text Demo</title>
-<h1>Upload audio for transcription</h1>
-<form method="post" enctype="multipart/form-data" action="/transcribe">
-  Base URL: <input type="text" name="base_url" value="https://api.openai.com/v1"><br>
-  API Key: <input type="text" name="api_key"><br>
-  Model: <select name="model">
-    <option value="gpt-4o-mini-transcribe">gpt-4o-mini-transcribe</option>
-    <option value="gpt-4o-transcribe">gpt-4o-transcribe</option>
-  </select><br>
-  Audio File: <input type="file" name="audio"><br>
-  <input type="submit" value="Transcribe">
-</form>
-"""
 
 @app.route('/', methods=['GET'])
 def index():
-    return render_template_string(HTML_FORM)
+    return render_template('index.html')
 
 @app.route('/transcribe', methods=['POST'])
 def transcribe():
@@ -52,4 +37,4 @@ def transcribe():
     return jsonify({"text": text})
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=5000, debug=True)
+    app.run(host='0.0.0.0', port=5001, debug=True)

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,80 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>Speech to Text Demo</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+<div class="container py-5">
+  <h1 class="mb-4">Speech to Text Demo</h1>
+  <form id="uploadForm" class="mb-3" method="post" enctype="multipart/form-data" action="/transcribe">
+    <div class="mb-3">
+      <label class="form-label">Base URL</label>
+      <input type="text" class="form-control" name="base_url" value="https://api.openai.com/v1">
+    </div>
+    <div class="mb-3">
+      <label class="form-label">API Key</label>
+      <input type="text" class="form-control" name="api_key" required>
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Model</label>
+      <select class="form-select" name="model">
+        <option value="gpt-4o-mini-transcribe">gpt-4o-mini-transcribe</option>
+        <option value="gpt-4o-transcribe">gpt-4o-transcribe</option>
+      </select>
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Audio File</label>
+      <input type="file" class="form-control" name="audio">
+    </div>
+    <button type="submit" class="btn btn-primary">Transcribe File</button>
+  </form>
+
+  <hr>
+
+  <div class="mb-3">
+    <button id="recordBtn" class="btn btn-secondary">Start Recording</button>
+    <button id="stopBtn" class="btn btn-secondary d-none">Stop Recording</button>
+  </div>
+  <audio id="audioPlayback" class="d-none" controls></audio>
+  <pre id="resultText" class="mt-3"></pre>
+</div>
+
+<script>
+  let mediaRecorder;
+  let audioChunks = [];
+  const recordBtn = document.getElementById('recordBtn');
+  const stopBtn = document.getElementById('stopBtn');
+  const playback = document.getElementById('audioPlayback');
+  const result = document.getElementById('resultText');
+  const form = document.getElementById('uploadForm');
+
+  recordBtn.onclick = async () => {
+    audioChunks = [];
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    mediaRecorder = new MediaRecorder(stream);
+    mediaRecorder.ondataavailable = e => audioChunks.push(e.data);
+    mediaRecorder.onstop = async () => {
+      const blob = new Blob(audioChunks, { type: 'audio/webm' });
+      playback.src = URL.createObjectURL(blob);
+      playback.classList.remove('d-none');
+      const fd = new FormData(form);
+      fd.set('audio', blob, 'recording.webm');
+      const resp = await fetch('/transcribe', { method: 'POST', body: fd });
+      const data = await resp.json();
+      result.textContent = data.text || resp.statusText;
+    };
+    mediaRecorder.start();
+    recordBtn.classList.add('d-none');
+    stopBtn.classList.remove('d-none');
+  };
+
+  stopBtn.onclick = () => {
+    mediaRecorder.stop();
+    recordBtn.classList.remove('d-none');
+    stopBtn.classList.add('d-none');
+  };
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Replace inline HTML with a Bootstrap-styled template that supports microphone recording and file uploads.
- Update Flask app to render the new template and listen on port 5001.
- Refresh README to document new port and recording feature.

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_688e3c18f08c8332b3bcace89c86eb6b