### PR TITLE
Add streaming transcription option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,7 @@ python app.py
 ```
 
 Visit `http://localhost:5001` in your browser. The interface now includes a microphone button so you can record audio directly in the page, or upload an existing file. Provide your API key, optionally override the base URL, choose a model, and submit the audio to receive a transcription.
+
+### Streaming option
+
+Enable the **Stream transcription while recording** switch to send audio chunks to the server as they are captured. The server calls OpenAI's `audio.transcriptions.with_streaming_response.create` so the transcript area updates in near real time while you speak.

--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, request, render_template, jsonify
+from flask import Flask, request, render_template, jsonify, Response
 from openai import OpenAI
 import io
 
@@ -15,6 +15,7 @@ def transcribe():
     base_url = request.form.get('base_url') or "https://api.openai.com/v1"
     model = request.form.get('model', 'gpt-4o-mini-transcribe')
     audio = request.files.get('audio')
+    stream = request.args.get('stream') == '1'
 
     if not api_key or audio is None:
         return "Missing API key or audio file", 400
@@ -25,16 +26,31 @@ def transcribe():
     buf = io.BytesIO(audio_bytes)
     buf.name = audio.filename or 'audio.wav'
 
-    try:
-        result = client.audio.transcriptions.create(
-            model=model,
-            file=buf
-        )
-        text = result.text
-    except Exception as e:
-        return f"Error: {e}", 500
+    if stream:
+        def generate():
+            try:
+                with client.audio.transcriptions.with_streaming_response.create(
+                    model=model,
+                    file=buf
+                ) as response:
+                    for event in response:
+                        if event.type == "transcript.delta" and event.delta.get("text"):
+                            yield event.delta["text"]
+            except Exception as e:
+                yield f"Error: {e}"
 
-    return jsonify({"text": text})
+        return Response(generate(), mimetype='text/plain')
+    else:
+        try:
+            result = client.audio.transcriptions.create(
+                model=model,
+                file=buf
+            )
+            text = result.text
+        except Exception as e:
+            return f"Error: {e}", 500
+
+        return jsonify({"text": text})
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5001, debug=True)

--- a/templates/index.html
+++ b/templates/index.html
@@ -37,6 +37,10 @@
     <button id="recordBtn" class="btn btn-secondary">Start Recording</button>
     <button id="stopBtn" class="btn btn-secondary d-none">Stop Recording</button>
     <canvas id="waveform" class="w-100 border mt-3 d-none" height="100"></canvas>
+    <div class="form-check form-switch mt-3">
+      <input class="form-check-input" type="checkbox" id="streamingChk">
+      <label class="form-check-label" for="streamingChk">Stream transcription while recording</label>
+    </div>
   </div>
   <audio id="audioPlayback" class="d-none" controls></audio>
   <textarea id="resultText" class="form-control mt-3" rows="10" readonly></textarea>
@@ -52,24 +56,50 @@
   const form = document.getElementById('uploadForm');
   const canvas = document.getElementById('waveform');
   const canvasCtx = canvas.getContext('2d');
-  let audioCtx, analyser, dataArray, bufferLength, animationId;
+  const streamingChk = document.getElementById('streamingChk');
+  let audioCtx, analyser, dataArray, bufferLength, animationId, isStreaming;
 
   recordBtn.onclick = async () => {
     audioChunks = [];
+    isStreaming = streamingChk.checked;
     const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
     mediaRecorder = new MediaRecorder(stream);
-    mediaRecorder.ondataavailable = e => audioChunks.push(e.data);
-    mediaRecorder.onstop = async () => {
-      const blob = new Blob(audioChunks, { type: 'audio/webm' });
-      playback.src = URL.createObjectURL(blob);
+    mediaRecorder.ondataavailable = async e => {
+      if (e.data.size > 0) {
+        audioChunks.push(e.data);
+          if (isStreaming) {
+            const fd = new FormData(form);
+            fd.set('audio', e.data, 'chunk.webm');
+            try {
+              const resp = await fetch('/transcribe?stream=1', { method: 'POST', body: fd });
+              const reader = resp.body.getReader();
+              const decoder = new TextDecoder();
+              while (true) {
+                const { value, done } = await reader.read();
+                if (done) break;
+                const text = decoder.decode(value, { stream: true });
+                result.value += text;
+                result.scrollTop = result.scrollHeight;
+              }
+            } catch (err) {
+              console.error(err);
+            }
+          }
+        }
+      };
+      mediaRecorder.onstop = async () => {
+        const blob = new Blob(audioChunks, { type: 'audio/webm' });
+        playback.src = URL.createObjectURL(blob);
       playback.classList.remove('d-none');
-      const fd = new FormData(form);
-      fd.set('audio', blob, 'recording.webm');
-      const resp = await fetch('/transcribe', { method: 'POST', body: fd });
-      const data = await resp.json();
-      result.value += (result.value ? "\n" : "") + (data.text || resp.statusText);
-      result.scrollTop = result.scrollHeight;
-    };
+      if (!isStreaming) {
+        const fd = new FormData(form);
+        fd.set('audio', blob, 'recording.webm');
+          const resp = await fetch('/transcribe', { method: 'POST', body: fd });
+          const data = await resp.json();
+          result.value += (result.value ? "\n" : "") + (data.text || resp.statusText);
+          result.scrollTop = result.scrollHeight;
+        }
+      };
     audioCtx = new (window.AudioContext || window.webkitAudioContext)();
     const source = audioCtx.createMediaStreamSource(stream);
     analyser = audioCtx.createAnalyser();
@@ -103,7 +133,7 @@
       canvasCtx.stroke();
     };
     draw();
-    mediaRecorder.start();
+    mediaRecorder.start(isStreaming ? 1000 : undefined);
     recordBtn.classList.add('d-none');
     stopBtn.classList.remove('d-none');
   };


### PR DESCRIPTION
## Summary
- implement streaming transcription using OpenAI's official streaming API
- update recording interface to stream chunks and append partial text in real time
- document how streaming mode leverages `audio.transcriptions.with_streaming_response.create`

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_688e554b15588332bfa99746ecc9f2f9